### PR TITLE
Make adding variables support dict

### DIFF
--- a/src/airflow_bdd/steps/dag_steps.py
+++ b/src/airflow_bdd/steps/dag_steps.py
@@ -97,7 +97,7 @@ def given_all_tasks_of_type(task_type: Any, context: Context):
 @bdd
 def given_variable(key: str, value: Any, context: Context):
     from airflow.models import Variable
-    Variable.set(key, value)
+    Variable.set(key, value, serialize_json=isinstance(value, dict))
 
 
 @bdd


### PR DESCRIPTION
```gherkin
As a developer
When I supply a dict as a variable
It should be serialised as a json
```