### PR TITLE
Fix config discovery for airflow_bdd_config.py in tests directory

### DIFF
--- a/src/airflow_bdd/core/config.py
+++ b/src/airflow_bdd/core/config.py
@@ -42,13 +42,15 @@ _config_cache = {}
 
 def find_airflow_bdd_config(test_file_path):
     """Find airflow_bdd_config.py in common locations."""
+    # Normalize the test file path to handle absolute/relative paths
+    test_file_path = os.path.abspath(test_file_path)
     test_dir = os.path.dirname(test_file_path)
     home_dir = os.path.expanduser("~")
     
     # Find the tests directory by walking up the directory tree
     def find_tests_directory(start_path):
         """Walk up the directory tree to find the tests directory."""
-        current_path = start_path
+        current_path = os.path.abspath(start_path)
         while current_path != os.path.dirname(current_path):  # Stop at root
             if os.path.basename(current_path) == "tests":
                 return current_path

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -117,8 +117,30 @@ class TestFindAirflowBddConfig:
         test_file = tmp_path / "tests" / "test_something.py"
         test_file.write_text("# Test file")
         
-        result = find_airflow_bdd_config(str(test_file))
-        assert_that(result, equal_to(str(config_file)))
+        # Mock os.getcwd() to return the project root (parent of tests)
+        # This simulates running pytest from the project root where there's no config
+        with mock.patch('os.getcwd', return_value=str(tmp_path)):
+            result = find_airflow_bdd_config(str(test_file))
+            assert_that(result, equal_to(str(config_file)))
+
+    def test_find_config_in_tests_directory_with_subdirectory(self, tmp_path):
+        """Test finding config in tests directory when test file is in a subdirectory."""
+        # Create tests directory structure with subdirectory
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        subdir = tests_dir / "subdir"
+        subdir.mkdir()
+        config_file = tests_dir / "airflow_bdd_config.py"
+        config_file.write_text("# Test config")
+        
+        test_file = subdir / "test_something.py"
+        test_file.write_text("# Test file")
+        
+        # Mock os.getcwd() to return the project root (parent of tests)
+        # This simulates running pytest from the project root where there's no config
+        with mock.patch('os.getcwd', return_value=str(tmp_path)):
+            result = find_airflow_bdd_config(str(test_file))
+            assert_that(result, equal_to(str(config_file)))
 
     def test_find_config_in_home_directory(self, tmp_path):
         """Test finding config in user's home directory."""


### PR DESCRIPTION
- Add path normalization using os.path.abspath() to handle both absolute and relative paths
- Fix test_find_config_in_tests_directory to properly mock os.getcwd() to simulate pytest running from project root
- Add test case for test files in subdirectories of tests directory
- Ensures config file in tests folder is discovered when running pytest from another project