### PR TITLE
Add support for `clustering_fields` to `given_table`

### DIFF
--- a/src/airflow_bdd/steps/providers/google/bigquery/bigquery_steps.py
+++ b/src/airflow_bdd/steps/providers/google/bigquery/bigquery_steps.py
@@ -39,6 +39,7 @@ def given_table(
         schema: Union[str, List[Dict[str, Any]]],
         project_id: Optional[str] = None,
         dataset_id: Optional[str] = None,
+        clustering_fields: Optional[List[str]] = None,
         context: Optional[Context] = None):
     if "bigquery_client" not in context:
         given_bigquery_client(project_id=project_id)
@@ -46,15 +47,14 @@ def given_table(
     client: bigquery.Client = context["bigquery_client"]
     unique_table_id = f"{project_id or context.config.bigquery.project_id}.{dataset_id or context.config.bigquery.dataset_id}.{table_name}_{str(uuid.uuid4())[:5]}"
 
-    client.create_table(
-        table=bigquery.Table(
-            unique_table_id,            
-            schema=json.loads(open(schema).read()) if isinstance(schema, str) else schema,
-        ),
-        # TODO: Maybe not ok
-        exists_ok=True
+    table = bigquery.Table(
+        unique_table_id,
+        schema=json.loads(open(schema).read()) if isinstance(schema, str) else schema,
     )
+    if clustering_fields:
+        table.clustering_fields = clustering_fields
 
+    client.create_table(table=table, exists_ok=True)  # TODO: Maybe not ok
     context["bigquery_table"] = unique_table_id
     context[table_name] = unique_table_id
 


### PR DESCRIPTION
As a developer writing BDD tests
I want to specify `clustering_fields` when creating test tables with `given_table`
So that my test setup matches production tables that use BigQuery clustering
and my scenarios exercise the same table layout my DAG expects

Example:

```python
given_table(
    table_name="my_table",
    schema="tests/providers/google/bigquery/test_schema.json",
    clustering_fields=["user_id", "event_date"],
)
```